### PR TITLE
fix to get service to auto restart on ubuntu

### DIFF
--- a/bind/config.sls
+++ b/bind/config.sls
@@ -49,7 +49,7 @@ bind_config:
     - require:
       - pkg: bind
     - watch_in:
-      - service: bind
+      - service: {{ map.service }}
 
 bind_local_config:
   file.managed:


### PR DESCRIPTION
{{ map.service }} should resolve to "bind9" as that's the service name on Ubuntu (the service gets configured correctly)
